### PR TITLE
misc tweaks

### DIFF
--- a/jlrun.jl
+++ b/jlrun.jl
@@ -1,41 +1,37 @@
 #!/usr/bin/env julia
-using Pkg
 
 # Parse command line arguments
-if length(ARGS)==0
+if length(ARGS) == 0
     println("jlrun <package>[/<script>] ...")
     exit(1)
 end
 
 # Split out the script, if present
 parts = split(ARGS[1], "/")
-if length(parts)>2
+if length(parts) > 2
     println("jlrun <package>[/<script>] ...")
     exit(2)
 end
 
 # Extract values from arguments
 pkg = parts[1]
-script = length(parts)==2 ? parts[2] : "run"
+script = get(parts, 2, "run")
 
-# Trigger package where script exists to be loaded
-eval(Meta.parse("using $(pkg)"))
-# Get the Module object for that package
-m = eval(Meta.parse(pkg))
+# Identify and locate package
+pkg = Base.identify_package(String(pkg))
+if pkg == nothing
+    println("package $pkg not found in environment")
+    exit(2)
+end
+loc = Base.locate_package(pkg)
+if loc == nothing
+    println("package $pkg not downloaded")
+    exit(2)
+end
+
 # Get the directory where the module is stored
-dir = Pkg.pkgdir(m)
+dir = joinpath(dirname(loc), "..")
 # Identify the actual file to run
 scriptfile = joinpath(dir, "scripts", "$(script).jl")
 
-# Point Julia to the environment associated with the package
-ENV["JULIA_PROJECT"] = dir
-
-cmd::Vector{String} = []
-push!(cmd, joinpath(Sys.BINDIR, Base.julia_exename()))
-push!(cmd, "--project=$(dir)")
-push!(cmd, scriptfile)
-for a in ARGS[2:length(ARGS)]
-    push!(cmd, a)
-end
-
-run(pipeline(Cmd(cmd)))
+run(`$(Base.julia_cmd()) --project=$dir $scriptfile $(ARGS[2:end]...)`)


### PR DESCRIPTION
- avoid depending on Pkg
- avoid having to load the package to find out where it resides. Otherwise you need to load the package twice, once in the jlrun executable and once when the script runs.
- minor stylistic changes
